### PR TITLE
Fix bug in Find Command

### DIFF
--- a/src/main/java/seedu/address/model/interview/InterviewContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewContainsKeywordsPredicate.java
@@ -31,19 +31,19 @@ public class InterviewContainsKeywordsPredicate implements Predicate<Interview> 
             List<String> names = fields.getAllValues(PREFIX_NAME);
             List<String> jobs = fields.getAllValues(PREFIX_JOB);
 
-            if (!dates.isEmpty() && dates.stream().noneMatch(d -> interview.getDate().toString().contains(d))) {
+            if (!dates.isEmpty() && !dates.stream().allMatch(d -> interview.getDate().toString().contains(d))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!times.isEmpty() && times.stream().noneMatch(t-> interview.getTime().toString().contains(t))) {
+            if (!times.isEmpty() && !times.stream().allMatch(t-> interview.getTime().toString().contains(t))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!names.isEmpty() && names.stream().noneMatch(n -> interview.getPerson().getName().contains(n))) {
+            if (!names.isEmpty() && !names.stream().allMatch(n -> interview.getPerson().getName().contains(n))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!jobs.isEmpty() && jobs.stream().noneMatch(j -> interview.getPerson().getJob().contains(j))) {
+            if (!jobs.isEmpty() && !jobs.stream().allMatch(j -> interview.getPerson().getJob().contains(j))) {
                 containsAllGroupTerms = false;
             }
 

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -37,27 +37,27 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
             List<String> jobs = fields.getAllValues(PREFIX_JOB);
             List<String> stages = fields.getAllValues(PREFIX_STAGE);
 
-            if (!names.isEmpty() && names.stream().noneMatch(n -> person.getName().contains(n))) {
+            if (!names.isEmpty() && !names.stream().allMatch(n -> person.getName().contains(n))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!phone.isEmpty() && phone.stream().noneMatch(p -> person.getPhone().contains(p))) {
+            if (!phone.isEmpty() && !phone.stream().allMatch(p -> person.getPhone().contains(p))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!emails.isEmpty() && emails.stream().noneMatch(e -> person.getEmail().contains(e))) {
+            if (!emails.isEmpty() && !emails.stream().allMatch(e -> person.getEmail().contains(e))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!addresses.isEmpty() && addresses.stream().noneMatch(a -> person.getAddress().contains(a))) {
+            if (!addresses.isEmpty() && !addresses.stream().allMatch(a -> person.getAddress().contains(a))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!jobs.isEmpty() && jobs.stream().noneMatch(j -> person.getJob().contains(j))) {
+            if (!jobs.isEmpty() && !jobs.stream().allMatch(j -> person.getJob().contains(j))) {
                 containsAllGroupTerms = false;
             }
 
-            if (!stages.isEmpty() && stages.stream().noneMatch(s -> person.getStage().contains(s))) {
+            if (!stages.isEmpty() && !stages.stream().allMatch(s -> person.getStage().contains(s))) {
                 containsAllGroupTerms = false;
             }
 


### PR DESCRIPTION
If 2 fields in a single group is used, the find checks only either one of the fields.
Bug fixed to -> now if 2 fields in a single group, make sure it matches all the fields.